### PR TITLE
removing ipad detection as mobile

### DIFF
--- a/src/services/ng2-device.service.ts
+++ b/src/services/ng2-device.service.ts
@@ -150,7 +150,6 @@ export class Device{
         let self = this;
         return [
             Constants.DEVICES.ANDROID,
-            Constants.DEVICES.I_PAD,
             Constants.DEVICES.IPHONE,
             Constants.DEVICES.I_POD,
             Constants.DEVICES.BLACKBERRY,


### PR DESCRIPTION
ipad device is already included in isTablet() which feels correct to me.